### PR TITLE
Precondition fulfillment awaited before deinit

### DIFF
--- a/Sources/TestingExpectation/Expectation.swift
+++ b/Sources/TestingExpectation/Expectation.swift
@@ -28,10 +28,10 @@ public actor Expectation {
 	/// An expected outcome in an asynchronous test.
 	/// - Parameters:
 	///   - expectedCount: The number of times `fulfill()` must be called before the expectation is completely fulfilled.
-	///   - conditionFulfillmentAwaited: When `true`, crashes in `deinit` when an expectation is created but its fulfillment has not been awaited.
+	///   - requireAwaitingFulfillment: Controls whether `deinit` requires that a created expectation has its fulfillment awaited.
 	public init(
 		expectedCount: UInt = 1,
-		conditionFulfillmentAwaited: Bool = true,
+		requireAwaitingFulfillment: Bool = true,
 		filePath: String = #filePath,
 		fileID: String = #fileID,
 		line: Int = #line,
@@ -42,7 +42,7 @@ public actor Expectation {
 			expect: { fulfilledWithExpectedCount, comment, sourceLocation in
 				#expect(fulfilledWithExpectedCount, comment, sourceLocation: sourceLocation)
 			},
-			precondition: conditionFulfillmentAwaited ? Swift.precondition : nil,
+			precondition: requireAwaitingFulfillment ? Swift.precondition : nil,
 			filePath: filePath,
 			fileID: fileID,
 			line: line,

--- a/TestingExpectation.podspec
+++ b/TestingExpectation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'TestingExpectation'
-  s.version  = '0.1.3'
+  s.version  = '0.1.4'
   s.license  = 'MIT'
   s.summary  = 'Create an asynchronous expectation in Swift Testing'
   s.homepage = 'https://github.com/dfed/swift-testing-expectation'

--- a/Tests/TestingExpectationTests/ExpectationTests.swift
+++ b/Tests/TestingExpectationTests/ExpectationTests.swift
@@ -77,7 +77,7 @@ struct ExpectationTests {
 	@MainActor // Global actor ensures Task ordering.
 	@Test
 	func fulfillment_waitsForFulfillment() async {
-		let systemUnderTest = Expectation(expectedCount: 1)
+		let systemUnderTest = Expectation(expectedCount: 1, conditionFulfillmentAwaited: false)
 		var hasFulfilled = false
 		let wait = Task {
 			await systemUnderTest.fulfillment(within: .seconds(10))
@@ -101,6 +101,42 @@ struct ExpectationTests {
 				}
 			)
 			await systemUnderTest.fulfillment(within: .zero)
+		}
+	}
+
+	@Test
+	func deinit_triggersTrueExpectationWhenNotAwaited() async {
+		let expect: @Sendable (Bool, Comment?, SourceLocation) -> Void = { _, _, _ in }
+		expect(true, nil, #_sourceLocation) // Force code coverage to cover the empty closure.
+		await confirmation { confirmation in
+			let unmanagedSystemUnderTest = Unmanaged.passRetained(Expectation(
+				expectedCount: 0,
+				expect: expect,
+				precondition: { condition, message, _, _ in
+					_ = message() // Force code coverage to cover the creation of the message.
+					#expect(condition())
+					confirmation()
+				}
+			))
+			await unmanagedSystemUnderTest.takeUnretainedValue().fulfillment(within: .zero)
+			unmanagedSystemUnderTest.release() // Force the system under test to deinit.
+		}
+	}
+
+	@Test
+	func deinit_triggersFalseExpectationWhenNotAwaited() async {
+		let expect: @Sendable (Bool, Comment?, SourceLocation) -> Void = { _, _, _ in }
+		expect(true, nil, #_sourceLocation) // Force code coverage to cover the empty closure.
+		await confirmation { confirmation in
+			_ = Expectation(
+				expectedCount: 1,
+				expect: expect,
+				precondition: { condition, message, _, _ in
+					_ = message() // Force code coverage to cover the creation of the message.
+					#expect(!condition())
+					confirmation()
+				}
+			)
 		}
 	}
 }

--- a/Tests/TestingExpectationTests/ExpectationTests.swift
+++ b/Tests/TestingExpectationTests/ExpectationTests.swift
@@ -77,7 +77,7 @@ struct ExpectationTests {
 	@MainActor // Global actor ensures Task ordering.
 	@Test
 	func fulfillment_waitsForFulfillment() async {
-		let systemUnderTest = Expectation(expectedCount: 1, conditionFulfillmentAwaited: false)
+		let systemUnderTest = Expectation(expectedCount: 1, requireAwaitingFulfillment: false)
 		var hasFulfilled = false
 		let wait = Task {
 			await systemUnderTest.fulfillment(within: .seconds(10))


### PR DESCRIPTION
Prevents adoptees of `Expectation` from accidentally creating an `Expectation` instance and not awaiting `fulfillment(within:)` on the `Expectation`

Resolves #12