### PR TITLE
Prevent link validation failure for confirmation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.md_dead_link_check]
+exclude_links = ["https://developer.apple.com/documentation/testing/confirmation(_:expectedcount:isolation:sourcelocation:_:)"]


### PR DESCRIPTION
CI is failing because it's mis-parsing the `confirmation` documentation link by stripping out the suffix